### PR TITLE
Assignment I: MatchMarkers

### DIFF
--- a/CodeBreaker/CodeBreaker/ContentView.swift
+++ b/CodeBreaker/CodeBreaker/ContentView.swift
@@ -10,12 +10,22 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            pegs(colors: [.red, .green, .green, .yellow])
+            pegs(colors: [.red, .blue, .green, .red])
+            pegs(colors: [.red, .yellow, .green, .blue])
         }
         .padding()
+    }
+    
+    func pegs(colors: [Color]) -> some View {
+        HStack {
+            ForEach(colors.indices, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 10)
+                    .aspectRatio(1, contentMode: .fit)
+                    .foregroundStyle(colors[index])
+            }
+            MatchMarkers(matches: [.exact, .inexact, .nomatch, .exact])
+        }
     }
 }
 

--- a/CodeBreaker/CodeBreaker/MatchMarkers.swift
+++ b/CodeBreaker/CodeBreaker/MatchMarkers.swift
@@ -63,11 +63,12 @@ struct MatchMarkersPreview: View {
     let matches: [Match]
     var body: some View {
         HStack {
-            ForEach(1...5, id: \.self) {_ in
+            ForEach(1...matches.count, id: \.self) {_ in
                 RoundedRectangle(cornerRadius: 10)
                     .aspectRatio(1, contentMode: .fit)
             }
             MatchMarkers(matches: matches)
         }
+        .frame(maxHeight: 40)
     }
 }

--- a/CodeBreaker/CodeBreaker/MatchMarkers.swift
+++ b/CodeBreaker/CodeBreaker/MatchMarkers.swift
@@ -38,10 +38,21 @@ struct MatchMarkers: View {
 }
 
 #Preview {
-    VStack {
+    let configurations: [[Match]] = [
+        [.exact, .inexact, .inexact],
+        [.exact, .nomatch, .nomatch],
+        [.exact, .inexact, .inexact, .exact, .nomatch],
+        [.exact, .inexact, .nomatch, .exact],
+        [.exact, .inexact],
+        [.exact, .inexact, .exact, .exact],
+        [.exact, .inexact, .inexact, .exact, .exact, .inexact],
+        [.exact, .inexact, .inexact, .exact, .inexact],
+        [.exact, .inexact, .inexact],
+    ]
+    VStack(alignment: .leading) {
         Spacer()
-        ForEach(1...9, id: \.self) {_ in
-            MatchMarkersPreview()
+        ForEach(configurations, id: \.self) { matches in
+            MatchMarkersPreview(matches: matches)
             Spacer()
         }
     }
@@ -49,12 +60,14 @@ struct MatchMarkers: View {
 }
 
 struct MatchMarkersPreview: View {
+    let matches: [Match]
     var body: some View {
         HStack {
             ForEach(1...5, id: \.self) {_ in
-                Circle()
+                RoundedRectangle(cornerRadius: 10)
+                    .aspectRatio(1, contentMode: .fit)
             }
-            MatchMarkers(matches: [.exact, .inexact, .inexact, .exact, .exact])
+            MatchMarkers(matches: matches)
         }
     }
 }

--- a/CodeBreaker/CodeBreaker/MatchMarkers.swift
+++ b/CodeBreaker/CodeBreaker/MatchMarkers.swift
@@ -16,13 +16,13 @@ struct MatchMarkers: View {
     
     var body: some View {
         HStack {
-            VStack {
-                matchMarker(peg: 0)
-                matchMarker(peg: 1)
-            }
-            VStack {
-                matchMarker(peg: 2)
-                matchMarker(peg: 3)
+            ForEach(0..<(matches.count + 1)/2, id: \.self) { matchGroup in
+                VStack {
+                    let startIndex = matchGroup * 2
+                    ForEach(startIndex..<startIndex + 2, id: \.self) { index in
+                        matchMarker(peg: index)
+                    }
+                }
             }
         }
     }
@@ -54,7 +54,7 @@ struct MatchMarkersPreview: View {
             ForEach(1...5, id: \.self) {_ in
                 Circle()
             }
-            MatchMarkers(matches: [.exact, .inexact, .nomatch, .exact])
+            MatchMarkers(matches: [.exact, .inexact, .inexact, .exact, .exact])
         }
     }
 }

--- a/CodeBreaker/CodeBreaker/MatchMarkers.swift
+++ b/CodeBreaker/CodeBreaker/MatchMarkers.swift
@@ -1,0 +1,42 @@
+//
+//  MatchMarkers.swift
+//  CodeBreaker
+//
+//  Created by Alexander Ostrovsky on 5/2/2026.
+//
+
+import SwiftUI
+
+enum Match {
+    case nomatch, exact, inexact
+}
+
+struct MatchMarkers: View {
+    var matches: [Match]
+    
+    var body: some View {
+        HStack {
+            VStack {
+                matchMarker(peg: 0)
+                matchMarker(peg: 1)
+            }
+            VStack {
+                matchMarker(peg: 2)
+                matchMarker(peg: 3)
+            }
+        }
+    }
+    
+    func matchMarker(peg: Int) -> some View {
+        let exactCount = matches.count(where: { $0 == .exact })
+        let foundCount = matches.count(where: { $0 != .nomatch })
+        return Circle()
+            .fill(exactCount > peg ? Color.primary : Color.clear)
+            .strokeBorder(foundCount > peg ? Color.primary : Color.clear, lineWidth: 2)
+            .aspectRatio(1, contentMode: .fit)
+    }
+}
+
+#Preview {
+    MatchMarkers(matches: [.exact, .inexact, .nomatch, .exact])
+}

--- a/CodeBreaker/CodeBreaker/MatchMarkers.swift
+++ b/CodeBreaker/CodeBreaker/MatchMarkers.swift
@@ -38,5 +38,23 @@ struct MatchMarkers: View {
 }
 
 #Preview {
-    MatchMarkers(matches: [.exact, .inexact, .nomatch, .exact])
+    VStack {
+        Spacer()
+        ForEach(1...9, id: \.self) {_ in
+            MatchMarkersPreview()
+            Spacer()
+        }
+    }
+    .padding()
+}
+
+struct MatchMarkersPreview: View {
+    var body: some View {
+        HStack {
+            ForEach(1...5, id: \.self) {_ in
+                Circle()
+            }
+            MatchMarkers(matches: [.exact, .inexact, .nomatch, .exact])
+        }
+    }
 }


### PR DESCRIPTION
Closes #4

## Summary

- `MatchMarkers` view supporting 3–6 pegs with proper layout
- Enhanced previews showing various match configurations alongside dummy pegs
- Dark mode and light mode support verified in previews

## Required Tasks

All 6 completed.